### PR TITLE
Rollback Go.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ workflows:
 jobs:
   test:
     docker:
-      - image: cimg/go:1.15
+      - image: cimg/go:1.15.2
     steps:
       - checkout
       - restore_cache:
@@ -54,7 +54,7 @@ jobs:
         type: boolean
         default: false
     docker:
-      - image: cimg/go:1.15
+      - image: cimg/go:1.15.2
     steps:
       - checkout
       - run:


### PR DESCRIPTION
A dependency two levels up, gotk3, has a problem with Go v1.15.3. Until one of the two things makes a fix, pinning Go v1.15.2.